### PR TITLE
added starrocks adapter macroses

### DIFF
--- a/macros/generate_source.sql
+++ b/macros/generate_source.sql
@@ -85,3 +85,72 @@
 {% endif %}
 
 {% endmacro %}
+
+{% macro starrocks__generate_source(schema_name, database_name, generate_columns, include_descriptions, include_data_types, table_pattern, exclude, name, table_names, include_database, include_schema, case_sensitive_databases, case_sensitive_schemas, case_sensitive_tables, case_sensitive_cols) %}
+
+{% set sources_yaml=[] %}
+{% do sources_yaml.append('version: 2') %}
+{% do sources_yaml.append('') %}
+{% do sources_yaml.append('sources:') %}
+{% do sources_yaml.append('  - name: ' ~ database_name | lower) %}
+
+{% if include_descriptions %}
+    {% do sources_yaml.append('    description: ""' ) %}
+{% endif %}
+
+{% if include_database %}
+{% do sources_yaml.append('    database: ' ~ (database_name if case_sensitive_databases else database_name | lower)) %}
+{% endif %}
+
+{% if schema_name != name or include_schema %}
+{% set full_schema = schema_name ~ '.' ~ database_name %}
+{% do sources_yaml.append('    schema: ' ~ (full_schema if case_sensitive_schemas else full_schema | lower)) %}
+{% endif %}
+
+{% do sources_yaml.append('    tables:') %}
+
+{% if table_names is none %}
+{% set tables=codegen.get_tables_in_schema(schema_name, database_name, table_pattern, exclude) %}
+{% else %}
+{% set tables = table_names %}
+{% endif %}
+
+{% for table in tables %}
+    {% do sources_yaml.append('      - name: ' ~ (table if case_sensitive_tables else table | lower) ) %}
+    {% if include_descriptions %}
+        {% do sources_yaml.append('        description: ""' ) %}
+    {% endif %}
+    {% if generate_columns %}
+    {% do sources_yaml.append('        columns:') %}
+
+        {% set table_relation=api.Relation.create(
+            schema=schema_name,
+            identifier=table
+        ) %}
+
+        {% set columns=adapter.get_columns_in_relation(table_relation) %}
+
+        {% for column in columns %}
+            {% do sources_yaml.append('          - name: ' ~ (column.name if case_sensitive_cols else column.name | lower)) %}
+            {% if include_data_types %}
+                {% do sources_yaml.append('            data_type: ' ~ codegen.data_type_format_source(column)) %}
+            {% endif %}
+            {% if include_descriptions %}
+                {% do sources_yaml.append('            description: ""' ) %}
+            {% endif %}
+        {% endfor %}
+            {% do sources_yaml.append('') %}
+
+    {% endif %}
+
+{% endfor %}
+
+{% if execute %}
+
+    {% set joined = sources_yaml | join ('\n') %}
+    {{ print(joined) }}
+    {% do return(joined) %}
+
+{% endif %}
+
+{% endmacro %}


### PR DESCRIPTION
resolves #

### Problem


The default generate_source macro assumes a traditional database → schema → table hierarchy.
However, in StarRocks, this structure is different:

Catalog (e.g. iceberg) maps to dbt's schema_name
Database (e.g. landing_chr_tj) maps to table_schema
Attempting to set database in a StarRocks Relation causes a runtime error (Cannot set database ... in StarRocks!)


### Solution


  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.


## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-codegen/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-codegen/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
